### PR TITLE
Handle incomplete reviews and supervisor comments

### DIFF
--- a/app/routes/director.py
+++ b/app/routes/director.py
@@ -22,6 +22,10 @@ async def director_view_review(request: Request, employee_id: str):
         db.close()
         return HTMLResponse("Funcionário ou avaliação não encontrada.", status_code=404)
 
+    if not review.employee_answers or not review.supervisor_answers:
+        db.close()
+        return HTMLResponse("Avaliação incompleta.", status_code=400)
+
     return templates.TemplateResponse("director_review.html", {
         "request": request,
         "employee": employee,

--- a/app/routes/home.py
+++ b/app/routes/home.py
@@ -24,7 +24,7 @@ async def home(request: Request):
 
     # Pending reviews for supervisor
     supervisor_pending = 0
-    if user.role == "supervisor":
+    if user.role == "supervisor" or user.is_supervisor:
         subordinates = db.query(Employee).filter_by(supervisor_email=user.email).all()
         for emp in subordinates:
             r = db.query(Review).filter_by(employee_id=emp.id).first()
@@ -45,7 +45,7 @@ async def home(request: Request):
         "request": request,
         "user": user,
         "employee_card_title": employee_card_title,
-        "show_supervisor_card": user.role == "supervisor",
+        "show_supervisor_card": user.role == "supervisor" or user.is_supervisor,
         "show_director_card": user.role == "director",
         "supervisor_pending": supervisor_pending,
         "director_pending": director_pending,

--- a/app/templates/director_review.html
+++ b/app/templates/director_review.html
@@ -12,7 +12,7 @@
       <div>
         <h2 class="text-xl font-semibold mb-2">Autoavaliação</h2>
         <ul class="space-y-4">
-          {% for answer in review.employee_answers %}
+          {% for answer in review.employee_answers or [] %}
             <li>
               <strong>{{ answer.question }}</strong><br />
               {% if answer.type == "scale" %}
@@ -20,6 +20,7 @@
               {% else %}
                 {{ answer.value }}
               {% endif %}
+              {% if answer.comment %}<br /><em>Comentário: {{ answer.comment }}</em>{% endif %}
             </li>
           {% endfor %}
         </ul>
@@ -28,7 +29,7 @@
       <div>
         <h2 class="text-xl font-semibold mb-2">Avaliação do Supervisor</h2>
         <ul class="space-y-4">
-          {% for answer in review.supervisor_answers %}
+          {% for answer in review.supervisor_answers or [] %}
             <li>
               <strong>{{ answer.question }}</strong><br />
               {% if answer.type == "scale" %}
@@ -36,6 +37,7 @@
               {% else %}
                 {{ answer.value }}
               {% endif %}
+              {% if answer.comment %}<br /><em>Comentário: {{ answer.comment }}</em>{% endif %}
             </li>
           {% endfor %}
         </ul>

--- a/app/templates/supervisor_review.html
+++ b/app/templates/supervisor_review.html
@@ -26,6 +26,7 @@
           {% elif q.type == "text" %}
             <textarea name="q{{ q.id }}" rows="4" class="w-full border p-2 rounded" {% if readonly %}disabled{% else %}required{% endif %}>{{ existing_map.get(q.question, '') }}</textarea>
           {% endif %}
+          <textarea name="c{{ q.id }}" rows="2" class="w-full border p-2 rounded mt-2" placeholder="Comentário (opcional)" {% if readonly %}disabled{% endif %}>{{ comment_map.get(q.question, '') }}</textarea>
         </div>
       {% endfor %}
 


### PR DESCRIPTION
## Summary
- allow directors that supervise to access the supervisor dashboard
- show supervisor card on home for directors marked as supervisors
- avoid crashes when viewing incomplete reviews
- let supervisors add comments per question

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=. python3 scripts/create_db.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68631cc8ba80832c806bd66657ad6560