### PR TITLE
Implement director comment per question and UI tweaks

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -27,7 +27,7 @@ class Review(Base):
     supervisor_id = Column(UUID(as_uuid=True), ForeignKey("employees.id"))
     employee_answers = Column(JSONB, nullable=True)
     supervisor_answers = Column(JSONB, nullable=True)
-    director_comments = Column(Text, nullable=True)
+    director_comments = Column(JSONB, nullable=True)
     status = Column(String, default="draft")
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -76,11 +76,13 @@ async def logout(request: Request):
     return RedirectResponse("/", status_code=302)
 
 @router.get("/usernames")
-def get_usernames(role: str = None):
+def get_usernames(role: str = None, exclude_directors: bool = False):
     db = SessionLocal()
     query = db.query(Employee.name)
     if role:
         query = query.filter(Employee.role == role)
+    elif exclude_directors:
+        query = query.filter(Employee.role != "director")
     names = query.all()
     db.close()
     return JSONResponse([name[0] for name in names])

--- a/app/routes/director.py
+++ b/app/routes/director.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 from app.db import SessionLocal
 from app.models import Employee, Review
 from app.utils.auth_utils import get_current_user
+from app.utils.questions import questions
 
 router = APIRouter()
 templates = Jinja2Templates(directory="app/templates")
@@ -25,17 +26,22 @@ async def director_view_review(request: Request, employee_id: str):
     if not review.employee_answers or not review.supervisor_answers:
         db.close()
         return HTMLResponse("Incomplete review.", status_code=400)
+    existing = review.director_comments or []
+    comment_map = {c["question"]: c.get("comment") for c in existing}
 
-    return templates.TemplateResponse("director_review.html", {
-        "request": request,
-        "employee": employee,
-        "review": review
-    })
+    return templates.TemplateResponse(
+        "director_review.html",
+        {
+            "request": request,
+            "employee": employee,
+            "review": review,
+            "questions": questions,
+            "comment_map": comment_map,
+        },
+    )
 
 @router.post("/director/review/{employee_id}/submit")
-async def save_director_comments(
-    request: Request, employee_id: str, director_comments: str = Form(...)
-):
+async def save_director_comments(request: Request, employee_id: str):
     current_user = get_current_user(request)
     db: Session = SessionLocal()
     review = db.query(Review).filter_by(employee_id=employee_id).first()
@@ -46,7 +52,13 @@ async def save_director_comments(
         db.close()
         return HTMLResponse("Review not found.", status_code=404)
 
-    review.director_comments = director_comments
+    form = await request.form()
+    comments = []
+    for q in questions:
+        comment = form.get(f"c{q['id']}")
+        comments.append({"question": q["question"], "comment": comment})
+
+    review.director_comments = comments
     db.commit()
     db.close()
 

--- a/app/templates/director_review.html
+++ b/app/templates/director_review.html
@@ -8,47 +8,34 @@
   <div class="max-w-5xl mx-auto bg-white p-6 rounded shadow">
     <h1 class="text-2xl font-bold mb-6">Final Review of {{ employee.name }}</h1>
 
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-6">
-      <div>
-        <h2 class="text-xl font-semibold mb-2">Self Review</h2>
-        <ul class="space-y-4">
-          {% for answer in review.employee_answers or [] %}
-            <li>
-              <strong>{{ answer.question }}</strong><br />
-              {% if answer.type == "scale" %}
-                Rating: {{ answer.value }}
+    <form method="post" action="/director/review/{{ employee.id }}/submit" class="space-y-6">
+      {% for idx, q in enumerate(questions) %}
+        <div>
+          <p class="font-semibold mb-1">{{ q.question }}</p>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm mb-2">
+            <div>
+              <strong>Self:</strong>
+              {% set ans = review.employee_answers[idx] %}
+              {% if ans.type == 'scale' %}
+                {{ ans.value }}
               {% else %}
-                {{ answer.value }}
+                {{ ans.value }}
               {% endif %}
-              {% if answer.comment %}<br /><em>Comment: {{ answer.comment }}</em>{% endif %}
-            </li>
-          {% endfor %}
-        </ul>
-      </div>
-
-      <div>
-        <h2 class="text-xl font-semibold mb-2">Supervisor Review</h2>
-        <ul class="space-y-4">
-          {% for answer in review.supervisor_answers or [] %}
-            <li>
-              <strong>{{ answer.question }}</strong><br />
-              {% if answer.type == "scale" %}
-                Rating: {{ answer.value }}
+            </div>
+            <div>
+              <strong>Supervisor:</strong>
+              {% set ans = review.supervisor_answers[idx] %}
+              {% if ans.type == 'scale' %}
+                {{ ans.value }}
               {% else %}
-                {{ answer.value }}
+                {{ ans.value }}
               {% endif %}
-              {% if answer.comment %}<br /><em>Comment: {{ answer.comment }}</em>{% endif %}
-            </li>
-          {% endfor %}
-        </ul>
-      </div>
-    </div>
-
-    <form method="post" action="/director/review/{{ employee.id }}/submit">
-      <div class="mb-4">
-        <label class="block font-semibold mb-1">Director Comments:</label>
-        <textarea name="director_comments" rows="6" class="w-full border p-2 rounded">{{ review.director_comments or '' }}</textarea>
-      </div>
+              {% if ans.comment %}<br /><em>Comment: {{ ans.comment }}</em>{% endif %}
+            </div>
+          </div>
+          <textarea name="c{{ q.id }}" rows="3" class="w-full border p-2 rounded" placeholder="Director comment">{{ comment_map.get(q.question, '') }}</textarea>
+        </div>
+      {% endfor %}
 
       <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
         Save Comments

--- a/app/templates/employee_review.html
+++ b/app/templates/employee_review.html
@@ -14,12 +14,14 @@
           <label class="block font-semibold mb-1">{{ q.question }}</label>
 
           {% if q.type == "scale" %}
-            <select name="q{{ q.id }}" required class="w-full border p-2 rounded">
-              <option value="">Select a rating</option>
+            <div class="flex space-x-2">
               {% for i in range(1,6) %}
-                <option value="{{ i }}">{{ i }}</option>
+                <label class="inline-flex items-center">
+                  <input type="radio" name="q{{ q.id }}" value="{{ i }}" class="mr-1" required>
+                  {{ i }}
+                </label>
               {% endfor %}
-            </select>
+            </div>
 
           {% elif q.type == "text" %}
             <textarea name="q{{ q.id }}" rows="4" class="w-full border p-2 rounded" required></textarea>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -6,6 +6,7 @@
 </head>
 <body class="bg-gray-100 p-8">
   <div class="max-w-4xl mx-auto space-y-6">
+    <img src="/static/logo.png" alt="Logo" class="h-12 mb-2" />
     <h1 class="text-2xl font-bold">Hello, {{ user.name }}!</h1>
     <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
       <a href="/employee/{{ user.id }}" class="block bg-white p-6 rounded shadow hover:bg-gray-50">

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -13,7 +13,7 @@
     {% if error %}
     <p class="text-center text-red-600">{{ error }}</p>
     {% endif %}
-    <div x-data="{ query: '', users: [], filtered: [] }" x-init="fetch('/usernames{% if director_only %}?role=director{% endif %}').then(res => res.json()).then(data => users = data)">
+    <div x-data="{ query: '', users: [], filtered: [] }" x-init="fetch('/usernames{% if director_only %}?role=director{% else %}?exclude_directors=1{% endif %}').then(res => res.json()).then(data => users = data)">
       <label class="block font-semibold">Name</label>
       <input name="name" x-model="query" @input="filtered = users.filter(u => u.toLowerCase().includes(query.toLowerCase())).slice(0, 5)" type="text" placeholder="Start typing your name..." class="w-full p-2 border rounded" required autocomplete="off">
       <ul class="bg-white border rounded mt-1" x-show="filtered.length > 0">


### PR DESCRIPTION
## Summary
- update username endpoint to optionally exclude directors
- fetch non-director usernames for regular login
- show logo on home screen
- use radio buttons for self reviews
- allow directors to leave a comment for each question

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68657eb36484832c934ffac2cd22f284