### PR TITLE
Adjust supervisor comments and employee review read-only

### DIFF
--- a/app/routes/supervisor.py
+++ b/app/routes/supervisor.py
@@ -118,7 +118,7 @@ async def submit_supervisor_review(request: Request, employee_id: str):
 
     for q in questions:
         value = form.get(f"q{q['id']}")
-        comment = form.get(f"c{q['id']}")
+        comment = form.get(f"c{q['id']}") if q["type"] == "scale" else None
         if q["type"] == "scale":
             value = int(value) if value else None
         answers.append(

--- a/app/templates/employee_review.html
+++ b/app/templates/employee_review.html
@@ -17,19 +17,20 @@
             <div class="flex space-x-2">
               {% for i in range(1,6) %}
                 <label class="inline-flex items-center">
-                  <input type="radio" name="q{{ q.id }}" value="{{ i }}" class="mr-1" required>
+                  <input type="radio" name="q{{ q.id }}" value="{{ i }}" class="mr-1" {% if existing_map.get(q.question) == i %}checked{% endif %} {% if readonly %}disabled{% else %}required{% endif %}>
                   {{ i }}
                 </label>
               {% endfor %}
             </div>
 
           {% elif q.type == "text" %}
-            <textarea name="q{{ q.id }}" rows="4" class="w-full border p-2 rounded" required></textarea>
+            <textarea name="q{{ q.id }}" rows="4" class="w-full border p-2 rounded" {% if readonly %}disabled{% else %}required{% endif %}>{{ existing_map.get(q.question, '') }}</textarea>
           {% endif %}
         </div>
       {% endfor %}
-
+      {% if not readonly %}
       <button type="submit" class="bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700">Submit Answers</button>
+      {% endif %}
     </form>
   </div>
 </body>

--- a/app/templates/supervisor_review.html
+++ b/app/templates/supervisor_review.html
@@ -26,7 +26,9 @@
           {% elif q.type == "text" %}
             <textarea name="q{{ q.id }}" rows="4" class="w-full border p-2 rounded" {% if readonly %}disabled{% else %}required{% endif %}>{{ existing_map.get(q.question, '') }}</textarea>
           {% endif %}
+          {% if q.type == "scale" %}
           <textarea name="c{{ q.id }}" rows="2" class="w-full border p-2 rounded mt-2" placeholder="Comment (optional)" {% if readonly %}disabled{% endif %}>{{ comment_map.get(q.question, '') }}</textarea>
+          {% endif %}
         </div>
       {% endfor %}
 


### PR DESCRIPTION
## Summary
- restrict employee self-review to read-only once submitted
- remove comment fields from text questions for supervisors
- keep supervisor comments only for rating questions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865921b0450832c87a7595315e0e02e